### PR TITLE
Add admin bot skeleton with FSM flows and metrics endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app/bot/__init__.py
+++ b/app/bot/__init__.py
@@ -1,0 +1,7 @@
+"""MG Digest bot package.
+
+This package implements admin bot with FSM flows for master login, source management,
+prompt editing, model/key management, pipeline control, schedule editing and
+moderation UI.
+"""
+

--- a/app/bot/config.py
+++ b/app/bot/config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Settings:
+    """Application settings loaded from environment variables."""
+
+    bot_token: str
+    admin_ids: List[int]
+    http_host: str = "0.0.0.0"
+    http_port: int = 8080
+
+
+def load_settings() -> Settings:
+    """Load :class:`Settings` from environment variables.
+
+    Environment variables:
+        BOT_TOKEN: Telegram bot token.
+        ADMIN_IDS: Comma separated list of administrator Telegram user IDs.
+        HTTP_HOST: Host for health/metrics server. Defaults to 0.0.0.0.
+        HTTP_PORT: Port for health/metrics server. Defaults to 8080.
+    """
+
+    bot_token = os.getenv("BOT_TOKEN", "")
+    raw_admins = os.getenv("ADMIN_IDS", "")
+    admin_ids = [int(x) for x in raw_admins.split(",") if x.strip()]
+    http_host = os.getenv("HTTP_HOST", "0.0.0.0")
+    http_port = int(os.getenv("HTTP_PORT", "8080"))
+    return Settings(
+        bot_token=bot_token,
+        admin_ids=admin_ids,
+        http_host=http_host,
+        http_port=http_port,
+    )
+
+
+__all__ = ["Settings", "load_settings"]

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -1,0 +1,138 @@
+"""Telegram command handlers for admin bot."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from aiogram import F, Router, types
+from aiogram.filters import Command, CommandStart
+from aiogram.fsm.context import FSMContext
+
+from .middleware.admin import AdminFilter
+from .states import (
+    MasterLogin,
+    ModelKey,
+    Moderation,
+    PipelineControl,
+    PromptEdit,
+    ScheduleEdit,
+    SourceManage,
+)
+
+
+async def _cancel_state(message: types.Message, state: FSMContext) -> None:
+    await state.clear()
+    await message.answer("Cancelled.")
+
+
+def setup_router(admin_ids: Iterable[int]) -> Router:
+    """Create router with all handlers and admin filter."""
+    router = Router()
+    router.message.filter(AdminFilter(admin_ids))
+
+    @router.message(CommandStart())
+    async def cmd_start(message: types.Message) -> None:
+        await message.answer("MG Digest admin bot")
+
+    # Master login flow
+    @router.message(Command("login"))
+    async def login_start(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(MasterLogin.phone)
+        await message.answer("Send master phone number:")
+
+    @router.message(MasterLogin.phone, F.text)
+    async def login_phone(message: types.Message, state: FSMContext) -> None:
+        await state.update_data(phone=message.text)
+        await state.set_state(MasterLogin.code)
+        await message.answer("Enter login code:")
+
+    @router.message(MasterLogin.code, F.text)
+    async def login_code(message: types.Message, state: FSMContext) -> None:
+        await state.update_data(code=message.text)
+        await state.set_state(MasterLogin.password)
+        await message.answer("Enter 2FA password or send - if not set:")
+
+    @router.message(MasterLogin.password, F.text)
+    async def login_password(message: types.Message, state: FSMContext) -> None:
+        # Stub: here Telethon login would be performed
+        await state.clear()
+        await message.answer("Master logged in (stub).")
+
+    # Source management
+    @router.message(Command("sources"))
+    async def sources_menu(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(SourceManage.waiting_action)
+        await message.answer("Send source name to toggle or /cancel:")
+
+    @router.message(SourceManage.waiting_action, F.text)
+    async def sources_toggle(message: types.Message, state: FSMContext) -> None:
+        await state.clear()
+        await message.answer(f"Toggled source {message.text} (stub).")
+
+    # Prompt editor
+    @router.message(Command("prompt"))
+    async def prompt_edit(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(PromptEdit.waiting_text)
+        await message.answer("Send new prompt text:")
+
+    @router.message(PromptEdit.waiting_text, F.text)
+    async def prompt_save(message: types.Message, state: FSMContext) -> None:
+        await state.clear()
+        await message.answer("Prompt updated (stub).")
+
+    # Model/key management
+    @router.message(Command("model"))
+    async def model_choose(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(ModelKey.waiting_model)
+        await message.answer("Send model name:")
+
+    @router.message(ModelKey.waiting_model, F.text)
+    async def model_set(message: types.Message, state: FSMContext) -> None:
+        await state.update_data(model=message.text)
+        await state.set_state(ModelKey.waiting_key)
+        await message.answer("Send API key:")
+
+    @router.message(ModelKey.waiting_key, F.text)
+    async def model_key_save(message: types.Message, state: FSMContext) -> None:
+        data = await state.get_data()
+        model = data.get("model")
+        await state.clear()
+        await message.answer(f"Key for {model} saved (stub).")
+
+    # Pipeline control
+    @router.message(Command("pipeline"))
+    async def pipeline_control(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(PipelineControl.confirm)
+        await message.answer("Send on/off to control pipeline:")
+
+    @router.message(PipelineControl.confirm, F.text)
+    async def pipeline_set(message: types.Message, state: FSMContext) -> None:
+        await state.clear()
+        await message.answer(f"Pipeline set to {message.text} (stub).")
+
+    # Schedule editor
+    @router.message(Command("schedule"))
+    async def schedule_edit(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(ScheduleEdit.waiting_cron)
+        await message.answer("Send cron expression:")
+
+    @router.message(ScheduleEdit.waiting_cron, F.text)
+    async def schedule_save(message: types.Message, state: FSMContext) -> None:
+        await state.clear()
+        await message.answer("Schedule updated (stub).")
+
+    # Moderation UI
+    @router.message(Command("moderate"))
+    async def moderation_start(message: types.Message, state: FSMContext) -> None:
+        await state.set_state(Moderation.reviewing)
+        await message.answer("Nothing to moderate (stub).")
+
+    # Cancel handler
+    @router.message(Command("cancel"))
+    async def cancel(message: types.Message, state: FSMContext) -> None:
+        await _cancel_state(message, state)
+
+    return router
+
+
+__all__ = ["setup_router"]

--- a/app/bot/logging.py
+++ b/app/bot/logging.py
@@ -1,0 +1,40 @@
+"""Logging configuration with sensitive data masking."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import structlog
+
+
+SENSITIVE_FIELDS = {"token", "api_key", "phone", "password", "code"}
+
+
+def mask_sensitive_data(_: Any, __: Any, event_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Mask sensitive values in log records."""
+    for key in list(event_dict.keys()):
+        if key in SENSITIVE_FIELDS and isinstance(event_dict[key], str):
+            value = event_dict[key]
+            if len(value) > 4:
+                event_dict[key] = f"{value[:2]}***{value[-2:]}"
+            else:
+                event_dict[key] = "***"
+    return event_dict
+
+
+def setup_logging() -> None:
+    """Configure structlog with masking processor."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    structlog.configure(
+        processors=[
+            mask_sensitive_data,
+            structlog.processors.TimeStamper(fmt="ISO"),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+    )
+
+
+__all__ = ["setup_logging", "mask_sensitive_data", "SENSITIVE_FIELDS"]

--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -1,0 +1,59 @@
+"""Entry point for the Telegram admin bot."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import NoReturn
+
+from aiohttp import web
+from aiogram import Bot, Dispatcher
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
+
+from .config import load_settings
+from .handlers import setup_router
+from .logging import setup_logging
+
+
+async def health_handler(_: web.Request) -> web.Response:
+    return web.json_response({"status": "ok"})
+
+
+async def metrics_handler(_: web.Request) -> web.Response:
+    registry = CollectorRegistry(auto_describe=True)
+    output = generate_latest(registry)
+    return web.Response(body=output, content_type=CONTENT_TYPE_LATEST)
+
+
+async def run_http_server(host: str, port: int) -> None:
+    app = web.Application()
+    app.add_routes([web.get("/health", health_handler), web.get("/metrics", metrics_handler)])
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host=host, port=port)
+    await site.start()
+    await asyncio.Event().wait()  # run forever
+
+
+async def main_async() -> NoReturn:
+    setup_logging()
+    settings = load_settings()
+    bot = Bot(token=settings.bot_token)
+    dp = Dispatcher()
+    dp.include_router(setup_router(settings.admin_ids))
+
+    http_task = asyncio.create_task(run_http_server(settings.http_host, settings.http_port))
+    try:
+        await dp.start_polling(bot)
+    finally:
+        http_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await http_task
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/app/bot/middleware/admin.py
+++ b/app/bot/middleware/admin.py
@@ -1,0 +1,21 @@
+"""Middleware and filters to restrict access to administrators."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from aiogram import types
+from aiogram.filters import BaseFilter
+
+
+class AdminFilter(BaseFilter):
+    """Allow only administrators based on user ID."""
+
+    def __init__(self, admin_ids: Iterable[int]):
+        self.admin_ids: List[int] = list(admin_ids)
+
+    async def __call__(self, message: types.Message) -> bool:
+        return bool(message.from_user and message.from_user.id in self.admin_ids)
+
+
+__all__ = ["AdminFilter"]

--- a/app/bot/states.py
+++ b/app/bot/states.py
@@ -1,0 +1,48 @@
+"""Finite state machine definitions for bot flows."""
+
+from __future__ import annotations
+
+from aiogram.fsm.state import State, StatesGroup
+
+
+class MasterLogin(StatesGroup):
+    phone = State()
+    code = State()
+    password = State()
+
+
+class SourceManage(StatesGroup):
+    waiting_action = State()
+    editing_source = State()
+
+
+class PromptEdit(StatesGroup):
+    waiting_text = State()
+
+
+class ModelKey(StatesGroup):
+    waiting_model = State()
+    waiting_key = State()
+
+
+class PipelineControl(StatesGroup):
+    confirm = State()
+
+
+class ScheduleEdit(StatesGroup):
+    waiting_cron = State()
+
+
+class Moderation(StatesGroup):
+    reviewing = State()
+
+
+__all__ = [
+    "MasterLogin",
+    "SourceManage",
+    "PromptEdit",
+    "ModelKey",
+    "PipelineControl",
+    "ScheduleEdit",
+    "Moderation",
+]


### PR DESCRIPTION
## Summary
- add `app/bot` package with FSM flows for login, source management, prompt editing, model/key management, pipeline control, schedule editing and moderation
- expose `/health` and `/metrics` endpoints via aiohttp server
- restrict bot commands to `ADMIN_IDS` and mask sensitive values in logs

## Testing
- `python -m py_compile $(find app -name '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a03306098c8330bd99405540f3bb67