### PR TITLE
Add digest pipeline with moderation and cost tracking

### DIFF
--- a/app/common/llm_client.py
+++ b/app/common/llm_client.py
@@ -5,7 +5,10 @@ import os
 import time
 from typing import Any, Dict
 
-import requests
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - requests might be missing
+    requests = None  # type: ignore
 
 from .errors import LLMError
 
@@ -52,9 +55,9 @@ class LLMClient:
 
     # ---- provider implementations ----------------------------------
     def _openai_complete(self, prompt: str, **kwargs: Any) -> str:
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-        }
+        if not requests:
+            raise LLMError("requests library not available")
+        headers = {"Authorization": f"Bearer {self.api_key}"}
         payload: Dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
@@ -68,6 +71,8 @@ class LLMClient:
         return data["choices"][0]["message"]["content"]
 
     def _anthropic_complete(self, prompt: str, **kwargs: Any) -> str:
+        if not requests:
+            raise LLMError("requests library not available")
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": "2023-06-01",

--- a/app/tests/test_pipeline.py
+++ b/app/tests/test_pipeline.py
@@ -1,0 +1,77 @@
+import asyncio
+
+from app.worker.pipeline import Pipeline, Topic, AdminBotClient
+from app.common.utils import count_tokens, calculate_cost
+
+
+class FakeLLMClient:
+    provider = "openai"
+    model = "gpt-3.5-turbo"
+
+    def __init__(self, response: str = "summary") -> None:
+        self.response = response
+
+    def complete(self, prompt: str, **kwargs: object) -> str:
+        return self.response
+
+
+def test_split_topics_limit() -> None:
+    llm = FakeLLMClient()
+    pipeline = Pipeline(llm, AdminBotClient())
+    raw = "Topic1\n\nTopic2\n\nTopic3\n\nTopic4"
+    post = pipeline.parse(raw)
+    topics = pipeline.split_topics(post)
+    assert len(topics) == 3
+
+
+def test_assemble_digest_limit() -> None:
+    llm = FakeLLMClient()
+    pipeline = Pipeline(llm, AdminBotClient())
+    topics = [Topic(id=i, text="t", links=[], summary=str(i)) for i in range(1, 15)]
+    digest, remaining = pipeline.assemble_digest(topics)
+    assert len(digest) == 10
+    assert len(remaining) == 4
+
+
+def test_summarize_records_cost() -> None:
+    llm = FakeLLMClient("short summary")
+    pipeline = Pipeline(llm, AdminBotClient())
+    topic = Topic(id=1, text="hello world", links=[])
+    pipeline.summarize(topic)
+    tokens_in = count_tokens("hello world")
+    tokens_out = count_tokens("short summary")
+    rate_prompt = 0.001
+    rate_completion = 0.002
+    expected = int(round((calculate_cost(tokens_in, rate_prompt) + calculate_cost(tokens_out, rate_completion)) * 100))
+    assert topic.tokens_in == tokens_in
+    assert topic.tokens_out == tokens_out
+    assert topic.cost_cents == expected
+
+
+def test_expand_links_concurrency() -> None:
+    llm = FakeLLMClient()
+    pipeline = Pipeline(llm, AdminBotClient())
+    topics = [Topic(id=1, text="", links=["u1", "u2", "u3"])]
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fake_fetch(url: str) -> str:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        return url
+
+    pipeline.expand_links(topics, concurrency=2, fetch_func=fake_fetch)
+    assert max_in_flight <= 2
+    assert topics[0].expanded_links == {"u1": "u1", "u2": "u2", "u3": "u3"}
+
+
+def test_moderate_uses_admin_bot() -> None:
+    llm = FakeLLMClient()
+    admin = AdminBotClient(approve=False)
+    pipeline = Pipeline(llm, admin)
+    topic = Topic(id=1, text="t", links=[])
+    pipeline.moderate(topic)
+    assert topic.approved is False

--- a/app/worker/__init__.py
+++ b/app/worker/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import Pipeline, Topic, AdminBotClient
+
+__all__ = ["Pipeline", "Topic", "AdminBotClient"]

--- a/app/worker/pipeline.py
+++ b/app/worker/pipeline.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import urllib.request
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - yaml might be missing at runtime
+    yaml = None  # type: ignore
+
+from app.common.llm_client import LLMClient, LLMError
+from app.common.utils import calculate_cost, count_tokens
+
+
+@dataclass
+class Topic:
+    """Container for an individual topic extracted from a post."""
+
+    id: int
+    text: str
+    links: List[str]
+    expanded_links: Dict[str, str] = field(default_factory=dict)
+    summary: str = ""
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_cents: int = 0
+    approved: bool = False
+
+
+class AdminBotClient:
+    """Very small stub representing an admin bot.
+
+    Real implementation would interact with Telegram; here we only simulate
+    approvals by returning a preset decision.
+    """
+
+    def __init__(self, approve: bool = True) -> None:
+        self.approve = approve
+
+    def send_moderation_card(self, topic: Topic) -> bool:
+        return self.approve
+
+
+class Pipeline:
+    """Processing pipeline for digest generation."""
+
+    def __init__(
+        self,
+        llm_client: LLMClient,
+        admin_bot: AdminBotClient,
+        prices_path: str = "config/prices.yaml",
+        *,
+        error_threshold: int = 5,
+        cool_down_seconds: int = 60,
+    ) -> None:
+        self.llm = llm_client
+        self.admin_bot = admin_bot
+        with open(prices_path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+            if yaml:
+                self.prices = yaml.safe_load(text) or {}
+            else:  # very small YAML subset parser
+                self.prices = self._parse_prices(text)
+        self.error_threshold = error_threshold
+        self.cool_down_seconds = cool_down_seconds
+        self._error_count = 0
+        self._circuit_open_until = 0.0
+
+    def _parse_prices(self, text: str) -> Dict[str, Dict[str, Dict[str, float]]]:
+        """Parse a tiny subset of YAML used for price files.
+
+        Supports structures like::
+
+            provider:
+              model:
+                prompt: 0.001
+                completion: 0.002
+        """
+
+        data: Dict[str, Dict[str, Dict[str, float]]] = {}
+        provider: Optional[str] = None
+        model: Optional[str] = None
+        for raw in text.splitlines():
+            if not raw.strip() or raw.lstrip().startswith("#"):
+                continue
+            if not raw.startswith(" "):
+                provider = raw.rstrip(":")
+                data[provider] = {}
+            elif raw.startswith("  ") and not raw.startswith("    "):
+                model = raw.strip().rstrip(":")
+                data[provider][model] = {}
+            else:
+                key, val = raw.strip().split(":", 1)
+                data[provider][model][key.strip()] = float(val.strip())
+        return data
+
+    # ---- stages -----------------------------------------------------
+    def parse(self, raw: str) -> Dict[str, List[str] | str]:
+        """Parse raw text and extract links."""
+        links = re.findall(r"https?://\S+", raw)
+        return {"text": raw, "links": links}
+
+    def split_topics(self, post: Dict[str, List[str] | str]) -> List[Topic]:
+        """Split post text into topics, up to three per post."""
+        chunks = [c.strip() for c in re.split(r"\n\s*\n", str(post["text"])) if c.strip()]
+        topics: List[Topic] = []
+        for idx, chunk in enumerate(chunks[:3], start=1):
+            links = re.findall(r"https?://\S+", chunk)
+            topics.append(Topic(id=idx, text=chunk, links=links))
+        return topics
+
+    def expand_links(
+        self,
+        topics: List[Topic],
+        *,
+        concurrency: int = 5,
+        fetch_func: Optional[Callable[[str], "asyncio.Future[str]"]] = None,
+    ) -> None:
+        """Fetch link contents concurrently with a limit."""
+
+        async def _default_fetch(url: str) -> str:
+            def _fetch() -> str:
+                with urllib.request.urlopen(url, timeout=10) as resp:
+                    return resp.read().decode("utf-8")
+
+            return await asyncio.to_thread(_fetch)
+
+        fetch_func = fetch_func or _default_fetch
+
+        async def _run() -> None:
+            sem = asyncio.Semaphore(concurrency)
+
+            async def _expand(topic: Topic) -> None:
+                results: Dict[str, str] = {}
+
+                async def _fetch(url: str) -> None:
+                    async with sem:
+                        results[url] = await fetch_func(url)
+
+                await asyncio.gather(*(_fetch(u) for u in topic.links))
+                topic.expanded_links = results
+
+            await asyncio.gather(*(_expand(t) for t in topics))
+
+        asyncio.run(_run())
+
+    def _check_circuit(self) -> None:
+        if time.time() < self._circuit_open_until:
+            raise LLMError("circuit breaker open")
+
+    def _record_success(self) -> None:
+        self._error_count = 0
+
+    def _record_failure(self) -> None:
+        self._error_count += 1
+        if self._error_count >= self.error_threshold:
+            self._circuit_open_until = time.time() + self.cool_down_seconds
+            self._error_count = 0
+
+    def summarize(self, topic: Topic) -> None:
+        """Summarize a topic using the LLM and record usage stats."""
+        self._check_circuit()
+        prompt = topic.text
+        for url, content in topic.expanded_links.items():
+            prompt += f"\nSource: {url}\n{content}\n"
+        tokens_in = count_tokens(prompt)
+        try:
+            result = self.llm.complete(prompt)
+        except LLMError:
+            self._record_failure()
+            raise
+        self._record_success()
+        tokens_out = count_tokens(result)
+        provider = self.llm.provider
+        model = self.llm.model
+        rate_prompt = float(self.prices[provider][model]["prompt"])
+        rate_completion = float(self.prices[provider][model]["completion"])
+        cost = calculate_cost(tokens_in, rate_prompt) + calculate_cost(
+            tokens_out, rate_completion
+        )
+        topic.summary = result
+        topic.tokens_in = tokens_in
+        topic.tokens_out = tokens_out
+        topic.cost_cents = int(round(cost * 100))
+
+    def moderate(self, topic: Topic) -> None:
+        """Send moderation card and store approval."""
+        topic.approved = self.admin_bot.send_moderation_card(topic)
+
+    def assemble_digest(self, topics: List[Topic]) -> tuple[List[Topic], List[Topic]]:
+        """Return (digest_topics, remaining_topics) respecting max 10 topics."""
+        digest = topics[:10]
+        remaining = topics[10:]
+        return digest, remaining
+
+    def publish(self, topics: List[Topic]) -> str:
+        """Combine topics into a digest string ready for posting."""
+        lines = [f"- {t.summary}" for t in topics]
+        return "\n".join(lines)
+
+
+__all__ = ["Pipeline", "Topic", "AdminBotClient"]


### PR DESCRIPTION
## Summary
- implement worker pipeline stages: parse, split_topics, expand_links, summarize, moderate, assemble_digest, publish
- track tokens and cost from `prices.yaml` with circuit breaker and link fetch concurrency
- add tests covering topic limits, digest limits, link concurrency, cost calculation, and moderation

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0342ae98483309acf7e0694f7eb29