### PR TITLE
Add Telegram digest formatting and flood-wait handling

### DIFF
--- a/app/common/telegram.py
+++ b/app/common/telegram.py
@@ -1,0 +1,118 @@
+"""Telegram helpers for publishing digest messages.
+
+Functions here handle building digest messages with proper
+formatting and sending them via a Telegram bot while respecting
+Telegram limitations.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Iterable, List, Sequence, TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from aiogram import Bot
+
+UTM_SOURCE = "tg_digest"
+UTM_MEDIUM = "post"
+CHUNK_LIMIT = 4096
+
+
+@dataclass
+class DigestItem:
+    """A single item in a digest."""
+
+    text: str
+    url: str
+    source_username: str
+
+
+def add_utm_params(url: str, campaign: date) -> str:
+    """Return ``url`` with UTM parameters appended."""
+    parsed = urlparse(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query.update(
+        {
+            "utm_source": UTM_SOURCE,
+            "utm_medium": UTM_MEDIUM,
+            "utm_campaign": campaign.strftime("%Y%m%d"),
+        }
+    )
+    new_query = urlencode(query)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def append_source_attribution(text: str, username: str) -> str:
+    """Append ``(@username)`` attribution to ``text``."""
+    return f"{text} (@{username})"
+
+
+def build_digest(items: Sequence[DigestItem], campaign: date) -> str:
+    """Build digest text from ``items`` with attribution and UTM tags."""
+    lines: List[str] = []
+    for item in items:
+        utm_url = add_utm_params(item.url, campaign)
+        line = f"• {item.text} <a href=\"{utm_url}\">[link]</a>"
+        line = append_source_attribution(line, item.source_username)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def chunk_text(text: str, limit: int = CHUNK_LIMIT) -> List[str]:
+    """Split ``text`` into chunks not exceeding ``limit`` characters."""
+    chunks: List[str] = []
+    while text:
+        if len(text) <= limit:
+            chunks.append(text)
+            break
+        cut = text.rfind("\n", 0, limit)
+        if cut == -1:
+            cut = text.rfind(" ", 0, limit)
+        if cut == -1:
+            cut = limit
+        chunks.append(text[:cut])
+        text = text[cut:].lstrip()
+    return chunks
+
+
+async def send_html(bot: "Bot", chat_id: int, text: str) -> List[datetime]:
+    """Send ``text`` to ``chat_id`` using ``parse_mode=HTML``.
+
+    The message is split into 4096-character chunks. Flood-wait errors
+    are handled by waiting and retrying. The ``posted_at`` timestamps
+    of successful messages are returned.
+    """
+    from aiogram.exceptions import TelegramRetryAfter
+
+    posted: List[datetime] = []
+    for chunk in chunk_text(text):
+        while True:
+            try:
+                msg = await bot.send_message(chat_id, chunk, parse_mode="HTML")
+                posted.append(msg.date)
+                break
+            except TelegramRetryAfter as e:  # pragma: no cover - network dependent
+                await asyncio.sleep(e.retry_after)
+    return posted
+
+
+async def publish_digest(bot: "Bot", chat_id: int, items: Sequence[DigestItem], campaign: date) -> List[datetime]:
+    """Build and send digest ``items`` to ``chat_id``.
+
+    Returns list of ``posted_at`` timestamps for sent messages.
+    """
+    text = build_digest(items, campaign)
+    return await send_html(bot, chat_id, text)
+
+
+__all__ = [
+    "DigestItem",
+    "add_utm_params",
+    "append_source_attribution",
+    "build_digest",
+    "chunk_text",
+    "send_html",
+    "publish_digest",
+]

--- a/app/tests/test_telegram_utils.py
+++ b/app/tests/test_telegram_utils.py
@@ -1,0 +1,37 @@
+from datetime import date
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.common.telegram import (
+    DigestItem,
+    add_utm_params,
+    append_source_attribution,
+    build_digest,
+    chunk_text,
+)
+
+
+def test_add_utm_params():
+    url = "https://example.com/path"
+    new_url = add_utm_params(url, date(2024, 5, 1))
+    assert "utm_source=tg_digest" in new_url
+    assert "utm_medium=post" in new_url
+    assert "utm_campaign=20240501" in new_url
+
+
+def test_append_source_attribution():
+    text = append_source_attribution("Summary", "source")
+    assert text.endswith("(@source)")
+
+
+def test_build_digest_and_chunking():
+    item = DigestItem("Hello", "https://example.com", "src")
+    digest = build_digest([item], date(2024, 5, 1))
+    assert "@src" in digest
+    assert "utm_campaign=20240501" in digest
+    long_text = "a" * 4100
+    chunks = chunk_text(long_text)
+    assert len(chunks) == 2
+    assert len(chunks[0]) == 4096


### PR DESCRIPTION
## Summary
- add Telegram helpers to build digest messages with HTML formatting, UTM tags and source attribution
- support 4096 character chunking, flood-wait retries and posted_at tracking
- test UTM tagging, attribution and chunking

## Testing
- `pytest app/tests/test_telegram_utils.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0343246e08330bdec8de80bc5c169