### PR TITLE
Add metrics, health endpoints and alerting hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository hosts the development of a Telegram-based digest system. The project aims to collect posts from selected channels, summarize them, and publish curated digests.
 
 For a detailed technical specification, see [docs/TECH_SPEC.md](docs/TECH_SPEC.md).
+
+## Monitoring
+
+Logging is provided via **structlog** in JSON format. Prometheus metrics such as `ingest_posts_total` and `summary_latency_seconds` are exposed together with a `/health` endpoint by `app.common.metrics.start_metrics_server`.
+
+Alerting helpers in `app.common.alerts` emit structured log events for situations like master session invalidation, LLM circuit breaker activation, digest publication failures, and empty digest releases.

--- a/app/common/alerts.py
+++ b/app/common/alerts.py
@@ -1,0 +1,39 @@
+"""Alerting hooks for notable error conditions."""
+
+from __future__ import annotations
+
+import structlog
+
+from .metrics import LLM_ERRORS_TOTAL, PUBLISH_FAILURES_TOTAL
+
+logger = structlog.get_logger()
+
+
+def alert_master_session_invalid() -> None:
+    """Alert when the master session becomes invalid."""
+    logger.error("master_session_invalid")
+
+
+def alert_llm_circuit_breaker() -> None:
+    """Alert when the LLM circuit breaker is triggered."""
+    LLM_ERRORS_TOTAL.inc()
+    logger.error("llm_circuit_breaker_triggered")
+
+
+def alert_digest_publication_failure() -> None:
+    """Alert when digest publication fails."""
+    PUBLISH_FAILURES_TOTAL.inc()
+    logger.error("digest_publication_failure")
+
+
+def alert_empty_release() -> None:
+    """Alert when a scheduled digest has no items to publish."""
+    logger.warning("empty_digest_release")
+
+
+__all__ = [
+    "alert_master_session_invalid",
+    "alert_llm_circuit_breaker",
+    "alert_digest_publication_failure",
+    "alert_empty_release",
+]

--- a/app/common/metrics.py
+++ b/app/common/metrics.py
@@ -1,0 +1,72 @@
+"""Prometheus metrics definitions and helpers."""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+try:  # pragma: no cover - dependency might be missing at runtime
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        Counter,
+        Histogram,
+        generate_latest,
+    )
+except Exception:  # pragma: no cover
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"  # type: ignore
+    Counter = Histogram = None  # type: ignore
+
+    def generate_latest(*args, **kwargs):  # type: ignore
+        return b""
+
+
+import structlog
+
+logger = structlog.get_logger()
+
+# Metric definitions
+INGEST_POSTS_TOTAL = Counter("ingest_posts_total", "Total number of posts ingested")
+SUMMARY_LATENCY_SECONDS = Histogram(
+    "summary_latency_seconds", "Latency of summary generation in seconds"
+)
+LLM_ERRORS_TOTAL = Counter("llm_errors_total", "Total number of LLM provider errors")
+PUBLISH_FAILURES_TOTAL = Counter(
+    "publish_failures_total", "Total number of digest publication failures"
+)
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    """HTTP handler exposing /metrics and /health endpoints."""
+
+    def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path == "/metrics":
+            data = generate_latest()
+            self.send_response(200)
+            self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+            self.end_headers()
+            self.wfile.write(data)
+        elif self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def start_metrics_server(port: int = 8000) -> ThreadingHTTPServer:
+    """Start a background HTTP server exposing metrics and health endpoints."""
+    server = ThreadingHTTPServer(("", port), _MetricsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    logger.info("metrics_server_started", port=port)
+    return server
+
+
+__all__ = [
+    "INGEST_POSTS_TOTAL",
+    "SUMMARY_LATENCY_SECONDS",
+    "LLM_ERRORS_TOTAL",
+    "PUBLISH_FAILURES_TOTAL",
+    "start_metrics_server",
+]


### PR DESCRIPTION
## Summary
- define Prometheus counters and histograms with a lightweight HTTP server exposing `/metrics` and `/health`
- add alert hooks logging notable failures and incrementing metrics
- document structured logging, metrics and alerting in README

## Testing
- `python -m py_compile app/common/metrics.py app/common/alerts.py`
- `pytest`
- `flake8 app/common/metrics.py app/common/alerts.py` *(fails: command not found)*
- `black app/common/metrics.py app/common/alerts.py`

------
https://chatgpt.com/codex/tasks/task_e_68a03435227c8330aeb8aed2fe553865