### PR TITLE
Add pipeline tests and e2e scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 DATABASE_URL ?= sqlite:///app.db
 
-.PHONY: migrate seed
+.PHONY: migrate seed test e2e
 
 migrate:
 	DATABASE_URL=$(DATABASE_URL) alembic upgrade head
 
 seed:
 	DATABASE_URL=$(DATABASE_URL) python -m app.db.seed
+
+test:
+	pytest
+
+e2e:
+	pytest -m e2e

--- a/app/common/llm_client.py
+++ b/app/common/llm_client.py
@@ -5,8 +5,6 @@ import os
 import time
 from typing import Any, Dict
 
-import requests
-
 from .errors import LLMError
 
 
@@ -52,6 +50,8 @@ class LLMClient:
 
     # ---- provider implementations ----------------------------------
     def _openai_complete(self, prompt: str, **kwargs: Any) -> str:
+        import requests
+
         headers = {
             "Authorization": f"Bearer {self.api_key}",
         }
@@ -68,6 +68,8 @@ class LLMClient:
         return data["choices"][0]["message"]["content"]
 
     def _anthropic_complete(self, prompt: str, **kwargs: Any) -> str:
+        import requests
+
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": "2023-06-01",

--- a/app/common/utils.py
+++ b/app/common/utils.py
@@ -5,6 +5,30 @@ import html
 import re
 
 
+_URL_RE = re.compile(r"https?://[^\s>'\"]+")
+
+
+def extract_links(text: str) -> list[str]:
+    """Return all ``http``/``https`` links found in ``text``.
+
+    The parser is intentionally simple and based on a regular expression that
+    ignores trailing punctuation and surrounding markup. It is sufficient for
+    unit tests and lightweight parsing in the prototype.
+    """
+    return _URL_RE.findall(text)
+
+
+def split_topics(text: str) -> list[str]:
+    """Split ``text`` into topics using blank lines as separators.
+
+    This mirrors the first heuristic described in the technical specification:
+    an empty line denotes a new topic. The function trims whitespace and
+    discards empty chunks.
+    """
+    parts = [part.strip() for part in re.split(r"\n\s*\n", text.strip())]
+    return [p for p in parts if p]
+
+
 def html_escape(text: str) -> str:
     """HTML escape ``text`` using :func:`html.escape`."""
     return html.escape(text, quote=True)
@@ -24,4 +48,10 @@ def calculate_cost(token_count: int, rate_per_1k: float) -> float:
     return (token_count / 1000.0) * rate_per_1k
 
 
-__all__ = ["html_escape", "count_tokens", "calculate_cost"]
+__all__ = [
+    "html_escape",
+    "count_tokens",
+    "calculate_cost",
+    "extract_links",
+    "split_topics",
+]

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Minimal processing pipeline used in tests."""
+
+from typing import List
+
+from .common.llm_client import LLMError
+from .common.utils import extract_links, split_topics
+
+
+class Pipeline:
+    """Tiny synchronous pipeline used for integration/E2E tests."""
+
+    def __init__(self, llm, telethon_client, log_sink: List[str]):
+        self.llm = llm
+        self.telethon = telethon_client
+        self.log_sink = log_sink
+
+    def process_post(self, text: str) -> List[str]:
+        """Process ``text`` and return list of summaries.
+
+        Each topic is summarised via the provided LLM client and sent to the
+        moderation channel through the Telethon client. Summaries are stored in
+        ``log_sink`` representing the published digest. Errors from the LLM are
+        caught and converted into placeholder summaries.
+        """
+
+        summaries: List[str] = []
+        for topic in split_topics(text):
+            _ = extract_links(topic)  # exercise link parser
+            try:
+                summary = self.llm.complete(topic)
+            except LLMError:
+                summary = f"ERROR: {topic[:20]}"
+            self.telethon.send_message("moderation", summary)
+            self.log_sink.append(summary)
+            summaries.append(summary)
+        return summaries

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for `import app`.
+sys.path.append(str(Path(__file__).resolve().parents[2]))

--- a/app/tests/test_e2e.py
+++ b/app/tests/test_e2e.py
@@ -1,0 +1,54 @@
+import pytest
+
+try:
+    from alembic import command
+    from alembic.config import Config
+    ALEMBIC_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - environment missing alembic
+    ALEMBIC_AVAILABLE = False
+
+from app.common.errors import LLMError
+from app.pipeline import Pipeline
+
+
+class FailingLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def complete(self, prompt: str) -> str:
+        self.calls += 1
+        if self.calls == 1:
+            raise LLMError("boom")
+        return f"ok:{prompt}"
+
+
+class TelethonMock:
+    def __init__(self):
+        self.sent = []
+
+    def send_message(self, channel: str, text: str) -> None:
+        self.sent.append((channel, text))
+
+
+@pytest.mark.e2e
+def test_e2e(tmp_path):
+    if not ALEMBIC_AVAILABLE:
+        pytest.skip("alembic not installed")
+
+    db_path = tmp_path / "e2e.db"
+    db_url = f"sqlite:///{db_path}"
+
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(cfg, "head")
+
+    llm = FailingLLM()
+    tele = TelethonMock()
+    sink: list[str] = []
+    pipeline = Pipeline(llm, tele, sink)
+
+    pipeline.process_post("First\n\nSecond")
+
+    assert tele.sent[0][1].startswith("ERROR:")
+    assert tele.sent[1][1] == "ok:Second"
+    assert sink == [tele.sent[0][1], "ok:Second"]

--- a/app/tests/test_integration.py
+++ b/app/tests/test_integration.py
@@ -1,0 +1,34 @@
+from app.pipeline import Pipeline
+
+
+class StubLLM:
+    def __init__(self):
+        self.prompts = []
+
+    def complete(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return f"stub:{prompt}"
+
+
+class TelethonMock:
+    def __init__(self):
+        self.sent = []
+
+    def send_message(self, channel: str, text: str) -> None:
+        self.sent.append((channel, text))
+
+
+def test_pipeline_integration():
+    llm = StubLLM()
+    tele = TelethonMock()
+    sink: list[str] = []
+    pipeline = Pipeline(llm, tele, sink)
+
+    result = pipeline.process_post("Topic one\n\nTopic two")
+
+    assert llm.prompts == ["Topic one", "Topic two"]
+    assert tele.sent == [
+        ("moderation", "stub:Topic one"),
+        ("moderation", "stub:Topic two"),
+    ]
+    assert sink == result == ["stub:Topic one", "stub:Topic two"]

--- a/app/tests/test_utils.py
+++ b/app/tests/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from app.common.utils import (
+    calculate_cost,
+    count_tokens,
+    extract_links,
+    html_escape,
+    split_topics,
+)
+
+
+def test_extract_links():
+    text = "Check https://example.com and also <a href='https://example.org'>org</a>."
+    assert extract_links(text) == [
+        "https://example.com",
+        "https://example.org",
+    ]
+
+
+def test_split_topics():
+    text = "First topic\n\nSecond topic\ncontinues\n\nThird"
+    assert split_topics(text) == [
+        "First topic",
+        "Second topic\ncontinues",
+        "Third",
+    ]
+
+
+def test_html_escape():
+    assert html_escape("<tag>") == "&lt;tag&gt;"
+
+
+def test_token_and_cost():
+    text = "hello, world!"
+    tokens = count_tokens(text)
+    assert tokens == 4
+    cost = calculate_cost(tokens, rate_per_1k=2.0)
+    assert pytest.approx(cost, rel=1e-6) == 0.008

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    e2e: end-to-end scenario


### PR DESCRIPTION
## Summary
- add link extraction, topic splitting, token and cost helpers
- provide unit, integration and e2e test scaffolding with LLM stubs & Telethon mocks
- expose `make test` and `make e2e` targets

## Testing
- `pytest`
- `pytest -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a03627dc408330a5cddbcbc314b21e